### PR TITLE
Footer renders to the left rather than the bottom of the page

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install dependencies
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
         python-version: 3.8


### PR DESCRIPTION
Weirdly the footer renders to the left of [this page](https://main-educational.github.io/intro_nilearn/functional-connectivity-with-nilearn.html). 

However, it renders fine on my local build. So I am guessing it has to do with the Python version of the environment created during the build. My local Python version is 3.12.7, but I am only testing 3.11 for now.